### PR TITLE
docs: add go run configuration option to MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ go build -o bin/mcp-server ./cmd/mcp-server
 ```
 
 ### 5. MCP Configuration
+
+#### Using Built Binary
 Create `.mcp.json` in the project directory:
 
 ```json
@@ -66,6 +68,21 @@ Create `.mcp.json` in the project directory:
   "description": "Google Cloud Observability MCP Server",
   "command": "./bin/mcp-server",
   "args": ["-transport", "stdio"],
+  "env": {
+    "GOOGLE_CLOUD_PROJECT": "your-project-id"
+  }
+}
+```
+
+#### Using go run
+For development or if you prefer to run without building:
+
+```json
+{
+  "name": "gcp-o11y",
+  "description": "Google Cloud Observability MCP Server",
+  "command": "go",
+  "args": ["run", "./cmd/mcp-server", "-transport", "stdio"],
   "env": {
     "GOOGLE_CLOUD_PROJECT": "your-project-id"
   }


### PR DESCRIPTION
## 概要

MCP 設定に `go run` を使用する開発向けオプションを README に追加しました。

## 変更内容

- **MCP Configuration** セクションを詳細化
- **バイナリ使用例**: ビルド済みバイナリを使用する `.mcp.json` 設定（既存）
- **go run 使用例**: 開発時に便利な `go run` を使用する `.mcp.json` 設定（新規追加）

## 背景

開発時やビルドプロセスを省略したい場合に、`go run` を使って直接 MCP サーバーを起動できる選択肢があると便利です。特に：

- プロトタイピング時のクイックセットアップ
- ビルドステップを省略したい開発環境
- CI/CD での動的な実行環境

## テスト計画

- [x] ドキュメントの記述内容が正確であることの確認
- [x] 両方の設定オプションが実際に機能することの確認

## 関連課題

なし（ドキュメント改善）